### PR TITLE
Mount /keybase/ sub-directories with defined permissions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,7 +160,7 @@ Vagrant.configure("2") do |config|
 
     if File.directory?(from_host)
       # parent dirs to be auto-created by synced_folder mount
-      config.vm.synced_folder from_host, to_guest
+      config.vm.synced_folder from_host, to_guest, mount_options: ["dmode=700,fmode=600"]
     else
       puts "WARNING: Failed to mount keybase.io VirtualFS"
       puts "  from_host: " + from_host


### PR DESCRIPTION
This is especially helpful for Windows where synced_folders might be mounted 0777 which will 
trip SSH with an error message like:

```
"Permissions 0777 for '/keybase/team/myteam/ssh/mycluster.domain.tld' are too open.", 
"It is required that your private key files are NOT accessible by others.", 
"This private key will be ignored."
```